### PR TITLE
Alternative syntax for MDX files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import {visit, SKIP} from 'unist-util-visit';
 
-const idRegex = / (?:{#|\|\|)(?<id>[^}]+)(?:}|\|\|)$/;
+const idRegex = / {#(?<id1>[^}]+)}$| \|\|(?<id2>[^|]+)\|\|$/;
 
 export default function remarkCustomHeaderId() {
 	return function (node) {
@@ -19,7 +19,8 @@ export default function remarkCustomHeaderId() {
 
 			textNode.value = text.slice(0, matched.index);
 
-			const {id} = matched.groups;
+			const {id1, id2} = matched.groups;
+			const id = id1 || id2;
 			node.data ??= {};
 			node.data.id = id;
 			node.data.hProperties ??= {};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 import {visit, SKIP} from 'unist-util-visit';
 
+// TODO: Use the same identifier for both when it's possible: https://github.com/tc39/proposal-duplicate-named-capturing-groups
 const idRegex = / {#(?<id1>[^}]+)}$| \|\|(?<id2>[^|]+)\|\|$/;
 
 export default function remarkCustomHeaderId() {
@@ -20,7 +21,7 @@ export default function remarkCustomHeaderId() {
 			textNode.value = text.slice(0, matched.index);
 
 			const {id1, id2} = matched.groups;
-			const id = id1 || id2;
+			const id = id1 ?? id2;
 			node.data ??= {};
 			node.data.id = id;
 			node.data.hProperties ??= {};

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import {visit, SKIP} from 'unist-util-visit';
 
-const idRegex = / {#(?<id>[^}]+)}$/;
+const idRegex = / (?:{#|\|\|)(?<id>[^}]+)(?:}|\|\|)$/;
 
 export default function remarkCustomHeaderId() {
 	return function (node) {

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,22 @@ export default defineConfig({
 });
 ```
 
+### Alternative syntax for MDX files
+
+The syntax `## Some header {#custom-id}` don't work inside MDX files.
+
+You can use one of these alternatives:
+
+- Escape curly braces: `\{#custom-id\}`
+- Use this syntax: `||custom-id||`
+
+Examples:
+
+`## Some header \{#custom-id\}`
+
+`## Some header ||custom-id||`
+
+
 ## API
 
 ### remarkCustomHeaderId()

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ export default defineConfig({
 
 ### Alternative syntax for MDX files
 
-The syntax `## Some header {#custom-id}` don't work inside MDX files.
+The `{#custom-id}` notation does not work in [MDX](https://mdxjs.com) files because MDX treats `{}` as JSX syntax, causing a parsing error. 
 
 You can use one of these alternatives:
 
@@ -58,10 +58,8 @@ You can use one of these alternatives:
 
 Examples:
 
-`## Some header \{#custom-id\}`
-
-`## Some header ||custom-id||`
-
+- `## Some header \{#custom-id\}`
+- `## Some header ||custom-id||`
 
 ## API
 

--- a/test.js
+++ b/test.js
@@ -19,6 +19,8 @@ test('main', async t => {
 # unicorn ||foo-bar||
 # a ||aa||
 ## c ||foo bar||
+# d {#wrong id|| 
+# e ||wrong id}
 	`.trim());
 
 	t.is(file.value, `
@@ -29,5 +31,7 @@ test('main', async t => {
 <h1 id="foo-bar">unicorn</h1>
 <h1 id="aa">a</h1>
 <h2 id="foo bar">c</h2>
+<h1>d {#wrong id||</h1>
+<h1>e ||wrong id}</h1>
 `.trim());
 });

--- a/test.js
+++ b/test.js
@@ -16,12 +16,18 @@ test('main', async t => {
 # a {#aa}
 # b
 ## c {#foo bar}
+# unicorn ||foo-bar||
+# a ||aa||
+## c ||foo bar||
 	`.trim());
 
 	t.is(file.value, `
 <h1 id="foo-bar">unicorn</h1>
 <h1 id="aa">a</h1>
 <h1>b</h1>
+<h2 id="foo bar">c</h2>
+<h1 id="foo-bar">unicorn</h1>
+<h1 id="aa">a</h1>
 <h2 id="foo bar">c</h2>
 `.trim());
 });


### PR DESCRIPTION
Fixes #2 

Little change in the regex pattern to match both the regular syntax `{#id}` and the alternative syntax `||id||`.

Changed test.js to include examples with the alternative syntax.

Changed readme.md to include a brief explanation and examples of use.

As a side effect, the regex pattern match some combinations of delimiters:  

`{#id||`  
`||id}`

But I think it is not a big deal. I don't see an easy way to change the regex without changing also the code. 


